### PR TITLE
Add missing feedback on addvalue and removevalue (#411)

### DIFF
--- a/src/main/java/com/iridium/iridiumskyblock/commands/AddValueCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/AddValueCommand.java
@@ -20,7 +20,7 @@ public class AddValueCommand extends Command {
     @Override
     public void execute(CommandSender sender, String[] args) {
         if (args.length != 3) {
-            sender.sendMessage(Utils.color(IridiumSkyblock.getConfiguration().prefix) + "/is addvalue <player> <amount>");
+            sender.sendMessage(Utils.color(IridiumSkyblock.getConfiguration().prefix) + " /is addvalue <player> <amount>");
             return;
         }
 
@@ -31,6 +31,7 @@ public class AddValueCommand extends Command {
                 if (island != null) {
                     try {
                         island.addExtraValue(Double.parseDouble(args[2]));
+                        sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().addedValue.replace("%value%", args[2]).replace("%player%", player.getName()).replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
                     } catch (NumberFormatException e) {
                         sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().notNumber.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix).replace("%error%", (args[2]))));
                     }
@@ -40,6 +41,8 @@ public class AddValueCommand extends Command {
             } else {
                 sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().playerOffline.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
             }
+        } else {
+            sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().playerOffline.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
         }
     }
 

--- a/src/main/java/com/iridium/iridiumskyblock/commands/RemoveValueCommand.java
+++ b/src/main/java/com/iridium/iridiumskyblock/commands/RemoveValueCommand.java
@@ -20,7 +20,7 @@ public class RemoveValueCommand extends Command {
     @Override
     public void execute(CommandSender sender, String[] args) {
         if (args.length != 3) {
-            sender.sendMessage(Utils.color(IridiumSkyblock.getConfiguration().prefix) + "/is removevalue <player> <amount>");
+            sender.sendMessage(Utils.color(IridiumSkyblock.getConfiguration().prefix) + " /is removevalue <player> <amount>");
             return;
         }
 
@@ -30,7 +30,12 @@ public class RemoveValueCommand extends Command {
                 Island island = User.getUser(player).getIsland();
                 if (island != null) {
                     try {
-                        island.removeExtraValue(Double.parseDouble(args[2]));
+                        if (Double.parseDouble(args[2]) <= island.getValue()) {
+                            island.removeExtraValue(Double.parseDouble(args[2]));
+                            sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().removedValue.replace("%value%", args[2]).replace("%player%", player.getName()).replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
+                        } else {
+                            sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().notEnoughValue.replace("%player%", player.getName()).replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
+                        }
                     } catch (NumberFormatException e) {
                         sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().notNumber.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix).replace("%error%", args[2])));
                     }
@@ -40,6 +45,8 @@ public class RemoveValueCommand extends Command {
             } else {
                 sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().playerOffline.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
             }
+        } else {
+            sender.sendMessage(Utils.color(IridiumSkyblock.getMessages().playerOffline.replace("%prefix%", IridiumSkyblock.getConfiguration().prefix)));
         }
     }
 

--- a/src/main/java/com/iridium/iridiumskyblock/configs/Messages.java
+++ b/src/main/java/com/iridium/iridiumskyblock/configs/Messages.java
@@ -133,8 +133,11 @@ public class Messages {
     public String cantExpelPlayer = "%prefix% &7%player% cannot be expelled!";
     public String cantExpelMember = "%prefix% &7%player% is in your island team";
     public String inviteHoverMessage = "Click to join players island!";
-    public String notNumber = "%prefix &7%error% is not a number!";
-    public String  coopHoverMessage = "Click to coop player's island!";
+    public String notNumber = "%prefix% &7%error% is not a number!";
+    public String coopHoverMessage = "Click to coop player's island!";
+    public String addedValue = "%prefix% &7%value% will be added to %player%'s island value on the next value update";
+    public String removedValue = "%prefix% &7%value% will be removed from %player%'s island value on the next value update";
+    public String notEnoughValue = "%prefix% &7%player%'s island does not have that much value!";
     public String purgingIslands = "%prefix% &7purging islands, Estimated time: %minutes% Minutes and %seconds% Seconds";
     public String purgingFinished = "%prefix% &7Purging islands Finished. Purged %amount% Islands";
     public String purgingAlreadyInProcess = "%prefix% &7Purging islands already in Process";


### PR DESCRIPTION
- Added confirmation message for /is addvalue and /is removevalue, including a check to avoid creating a negative island value. Returns an offline message in the event that Bukkit.getPlayer() doesn't return an object.

- Added missing % on prefix in notNumber message.

- Removed erroneous space in coopHoverMessage.